### PR TITLE
Fix VERR_FILE_NOT_FOUND error

### DIFF
--- a/integrator-analytics/Vagrantfile
+++ b/integrator-analytics/Vagrantfile
@@ -91,6 +91,7 @@ Vagrant.configure(2) do |config|
         vb.gui = false
         vb.customize ['modifyvm', :id, '--memory', memory]
         vb.customize ['modifyvm', :id, '--cpus', cpu]
+        vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
       end
       if server['conf_dir']
         server_config.vm.provision "file", source: FILES_PATH + server['conf_dir'], destination: DEFAULT_MOUNT + server['conf_dir']

--- a/integrator-bps-analytics/Vagrantfile
+++ b/integrator-bps-analytics/Vagrantfile
@@ -91,6 +91,7 @@ Vagrant.configure(2) do |config|
         vb.gui = false
         vb.customize ['modifyvm', :id, '--memory', memory]
         vb.customize ['modifyvm', :id, '--cpus', cpu]
+        vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
       end
       if server['conf_dir']
         server_config.vm.provision "file", source: FILES_PATH + server['conf_dir'], destination: DEFAULT_MOUNT + server['conf_dir']

--- a/integrator-broker-analytics/Vagrantfile
+++ b/integrator-broker-analytics/Vagrantfile
@@ -91,6 +91,7 @@ Vagrant.configure(2) do |config|
         vb.gui = false
         vb.customize ['modifyvm', :id, '--memory', memory]
         vb.customize ['modifyvm', :id, '--cpus', cpu]
+        vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
       end
       if server['conf_dir']
         server_config.vm.provision "file", source: FILES_PATH + server['conf_dir'], destination: DEFAULT_MOUNT + server['conf_dir']

--- a/integrator-broker-bps-analytics/Vagrantfile
+++ b/integrator-broker-bps-analytics/Vagrantfile
@@ -91,6 +91,7 @@ Vagrant.configure(2) do |config|
         vb.gui = false
         vb.customize ['modifyvm', :id, '--memory', memory]
         vb.customize ['modifyvm', :id, '--cpus', cpu]
+        vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
       end
       if server['conf_dir']
         server_config.vm.provision "file", source: FILES_PATH + server['conf_dir'], destination: DEFAULT_MOUNT + server['conf_dir']


### PR DESCRIPTION
## Purpose
Resloves https://github.com/wso2/vagrant-ei/issues/37.

## Goals
Remove the stray information Virtualbox packager includes to the Vagrant box.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
Vagrant 2.2.4
Virtualbox 5.2.18